### PR TITLE
pre-build script

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,10 @@
 steps:
   - name: 'gcr.io/cloud-builders/npm'
     args: [ 'install' ]
+  - name: 'debian'
+    args: [ 'bash', './preBuild.sh' ]
+    env:
+      - '___APIURL___=$_APIURL'
   - name: 'gcr.io/cloud-builders/npm'
     args: [ 'run', 'build' ]
   - name: 'gcr.io/cloud-builders/gsutil'

--- a/preBuild.sh
+++ b/preBuild.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+# replace placeholders in dist/environment/environment.ts
+
+# ___APIURL___
+sed -i "s|___APIURL___|$___APIURL___|g" "src/environments/environment.ts"

--- a/preBuild.sh
+++ b/preBuild.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-# replace placeholders in dist/environment/environment.ts
+# replace placeholders in dist/environment/environment.prod.ts
 
 # ___APIURL___
-sed -i "s|___APIURL___|$___APIURL___|g" "src/environments/environment.ts"
+sed -i "s|___APIURL___|$___APIURL___|g" "src/environments/environment.prod.ts"

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,0 @@
-export const environment = {
-  production: true
-};

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,0 +1,12 @@
+/*
+ * The placeholders, ____XXX___, are replaced
+ * from the preBuild.sh script.
+ * The environment variables comes from cloudbuild.
+ */
+
+export const environment = {
+  production: true,
+  io: {
+    url: '___APIURL___'
+  }
+};

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,19 +1,12 @@
-// This file can be replaced during build by using the `fileReplacements` array.
-// `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
-// The list of file replacements can be found in `angular.json`.
+/*
+ * The placeholders, ____XXX___, are replaced
+ * from the preBuild.sh script.
+ * The environment variables comes from cloudbuild.
+ */
 
 export const environment = {
-  production: false,
+  production: true,
   io: {
-    url: 'http://localhost:80'
+    url: '___APIURL___'
   }
 };
-
-/*
- * For easier debugging in development mode, you can import the following file
- * to ignore zone related error stack frames such as `zone.run`, `zoneDelegate.invokeTask`.
- *
- * This import should be commented out in production mode because it will have a negative impact
- * on performance if an error is thrown.
- */
-// import 'zone.js/dist/zone-error';  // Included with Angular CLI.

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,12 +1,19 @@
-/*
- * The placeholders, ____XXX___, are replaced
- * from the preBuild.sh script.
- * The environment variables comes from cloudbuild.
- */
+// This file can be replaced during build by using the `fileReplacements` array.
+// `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
+// The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: true,
+  production: false,
   io: {
-    url: '___APIURL___'
+    url: 'http://localhost:80'
   }
 };
+
+/*
+ * For easier debugging in development mode, you can import the following file
+ * to ignore zone related error stack frames such as `zone.run`, `zoneDelegate.invokeTask`.
+ *
+ * This import should be commented out in production mode because it will have a negative impact
+ * on performance if an error is thrown.
+ */
+// import 'zone.js/dist/zone-error';  // Included with Angular CLI.


### PR DESCRIPTION
Because Angular cannot replace environment variables during the build process, the preBuild.sh script replaces placeholders in the src/environments/environment.ts file that comes from cloudbuild.